### PR TITLE
Add external blog posts feature

### DIFF
--- a/src/components/writing/ExternalBlogPost.astro
+++ b/src/components/writing/ExternalBlogPost.astro
@@ -15,7 +15,7 @@ interface Props {
 const { post } = Astro.props;
 ---
 
-<div class="pb-4 pl-3 border-l-2 border-blue-400 dark:border-blue-500">
+<div class="pb-4">
   <a
     href={post.url}
     target="_blank"
@@ -51,14 +51,4 @@ const { post } = Astro.props;
   <time datetime={post.date.toISOString()}>
     {post.date.toDateString().split(" ").slice(1).join(" ")}
   </time>
-  {
-    post.description && (
-      <>
-        <br />
-        <span class="text-sm text-gray-600 dark:text-gray-400">
-          {post.description}
-        </span>
-      </>
-    )
-  }
 </div>

--- a/src/components/writing/ExternalBlogPost.astro
+++ b/src/components/writing/ExternalBlogPost.astro
@@ -1,15 +1,9 @@
 ---
 import WritingTags from "./WritingTags.astro";
+import type { ExternalPost } from "../../utils/posts";
 
 interface Props {
-  post: {
-    title: string;
-    url: string;
-    site: string;
-    date: Date;
-    tags?: string[];
-    description?: string;
-  };
+  post: ExternalPost;
 }
 
 const { post } = Astro.props;

--- a/src/components/writing/ExternalBlogPost.astro
+++ b/src/components/writing/ExternalBlogPost.astro
@@ -1,0 +1,64 @@
+---
+import WritingTags from "./WritingTags.astro";
+
+interface Props {
+  post: {
+    title: string;
+    url: string;
+    site: string;
+    date: Date;
+    tags?: string[];
+    description?: string;
+  };
+}
+
+const { post } = Astro.props;
+---
+
+<div class="pb-4 pl-3 border-l-2 border-blue-400 dark:border-blue-500">
+  <a
+    href={post.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="inline-flex items-center gap-1"
+  >
+    {post.title}
+    <svg
+      class="w-3 h-3 inline-block"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      ></path>
+    </svg>
+  </a>
+  <br />
+  <span class="text-sm text-blue-600 dark:text-blue-400 font-medium">
+    {post.site}
+  </span>
+  <br />
+  {
+    post.tags && post.tags.length > 0 && (
+      <WritingTags tags={post.tags} />
+    )
+  }
+  <time datetime={post.date.toISOString()}>
+    {post.date.toDateString().split(" ").slice(1).join(" ")}
+  </time>
+  {
+    post.description && (
+      <>
+        <br />
+        <span class="text-sm text-gray-600 dark:text-gray-400">
+          {post.description}
+        </span>
+      </>
+    )
+  }
+</div>

--- a/src/components/writing/WritingList.astro
+++ b/src/components/writing/WritingList.astro
@@ -1,6 +1,8 @@
 ---
 import WritingPost from "./WritingPost.astro";
 import ExternalBlogPost from "./ExternalBlogPost.astro";
+import { isExternalPost } from "../../utils/posts";
+
 const { posts } = Astro.props;
 ---
 
@@ -8,11 +10,9 @@ const { posts } = Astro.props;
   <ul class="list">
     {
       posts.map((item) => {
-        // Check if this is an external post (has a 'url' field)
-        if ("url" in item) {
+        if (isExternalPost(item)) {
           return <ExternalBlogPost post={item} />;
         }
-        // Otherwise it's an internal post entry
         return <WritingPost entry={item} />;
       })
     }

--- a/src/components/writing/WritingList.astro
+++ b/src/components/writing/WritingList.astro
@@ -1,11 +1,21 @@
 ---
 import WritingPost from "./WritingPost.astro";
+import ExternalBlogPost from "./ExternalBlogPost.astro";
 const { posts } = Astro.props;
 ---
 
 <section>
   <ul class="list">
-    {posts.map((entry) => <WritingPost entry={entry} />)}
+    {
+      posts.map((item) => {
+        // Check if this is an external post (has a 'url' field)
+        if ("url" in item) {
+          return <ExternalBlogPost post={item} />;
+        }
+        // Otherwise it's an internal post entry
+        return <WritingPost entry={item} />;
+      })
+    }
   </ul>
 </section>
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -37,7 +37,6 @@ const externalPostsCollection = defineCollection({
       site: z.string(),
       date: z.date(),
       tags: z.array(z.string()).optional(),
-      description: z.string().optional(),
     }),
   ),
 });

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -28,7 +28,22 @@ const talkCollection = defineCollection({
   }),
 });
 
+const externalPostsCollection = defineCollection({
+  type: "data",
+  schema: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string().url(),
+      site: z.string(),
+      date: z.date(),
+      tags: z.array(z.string()).optional(),
+      description: z.string().optional(),
+    }),
+  ),
+});
+
 export const collections = {
   writing: writingCollection,
   talks: talkCollection,
+  "external-posts": externalPostsCollection,
 };

--- a/src/content/external-posts/external-posts.yaml
+++ b/src/content/external-posts/external-posts.yaml
@@ -1,5 +1,5 @@
 - title: "AEP Terraform Provider"
-  url: "https://aep.dev/blog/terraform-provider/"
+  url: "https://aep.dev/blog/terraform-post/"
   site: "aep.dev"
   date: 2025-03-31
   tags: ["technology"]

--- a/src/content/external-posts/external-posts.yaml
+++ b/src/content/external-posts/external-posts.yaml
@@ -3,18 +3,15 @@
   site: "aep.dev"
   date: 2025-03-31
   tags: ["technology"]
-  description: "Introducing an auto-generated Terraform provider built on AEP-compliant APIs"
 
 - title: "Building Better APIs Together: AEP's 2024 Year in Review"
   url: "https://aep.dev/blog/2024-in-review/"
   site: "aep.dev"
   date: 2024-12-19
   tags: ["technology"]
-  description: "The API Enhancement Proposals project's major accomplishments throughout 2024"
 
 - title: "Announcing the aep-2026 Release"
   url: "https://aep.dev/blog/aep-2026-release/"
   site: "aep.dev"
   date: 2024-12-08
   tags: ["technology"]
-  description: "A stable API design specification addressing coordination challenges in software development"

--- a/src/content/external-posts/external-posts.yaml
+++ b/src/content/external-posts/external-posts.yaml
@@ -1,0 +1,19 @@
+# External blog posts
+# Add your external blog posts here following this format:
+#
+# - title: "Your Article Title"
+#   url: "https://example.com/your-article"
+#   site: "Website Name"
+#   date: 2024-01-15
+#   tags: ["tag1", "tag2"]  # Optional
+#   description: "A brief description"  # Optional
+
+# Example (remove or replace with your own posts):
+# - title: "My Article on Medium"
+#   url: "https://medium.com/@yourname/article"
+#   site: "Medium"
+#   date: 2024-01-15
+#   tags: ["technology"]
+#   description: "An interesting article about tech"
+
+[]  # Empty array - replace with your posts

--- a/src/content/external-posts/external-posts.yaml
+++ b/src/content/external-posts/external-posts.yaml
@@ -1,19 +1,20 @@
-# External blog posts
-# Add your external blog posts here following this format:
-#
-# - title: "Your Article Title"
-#   url: "https://example.com/your-article"
-#   site: "Website Name"
-#   date: 2024-01-15
-#   tags: ["tag1", "tag2"]  # Optional
-#   description: "A brief description"  # Optional
+- title: "AEP Terraform Provider"
+  url: "https://aep.dev/blog/terraform-provider/"
+  site: "aep.dev"
+  date: 2025-03-31
+  tags: ["technology"]
+  description: "Introducing an auto-generated Terraform provider built on AEP-compliant APIs"
 
-# Example (remove or replace with your own posts):
-# - title: "My Article on Medium"
-#   url: "https://medium.com/@yourname/article"
-#   site: "Medium"
-#   date: 2024-01-15
-#   tags: ["technology"]
-#   description: "An interesting article about tech"
+- title: "Building Better APIs Together: AEP's 2024 Year in Review"
+  url: "https://aep.dev/blog/2024-in-review/"
+  site: "aep.dev"
+  date: 2024-12-19
+  tags: ["technology"]
+  description: "The API Enhancement Proposals project's major accomplishments throughout 2024"
 
-[]  # Empty array - replace with your posts
+- title: "Announcing the aep-2026 Release"
+  url: "https://aep.dev/blog/aep-2026-release/"
+  site: "aep.dev"
+  date: 2024-12-08
+  tags: ["technology"]
+  description: "A stable API design specification addressing coordination challenges in software development"

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 
 import WritingList from "../components/writing/WritingList.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -8,7 +8,19 @@ const posts = await getCollection("writing", ({ data }) => {
   return import.meta.env.PROD ? data.draft !== true : true;
 });
 
-posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+// Get external posts
+const externalPostsEntry = await getEntry("external-posts", "external-posts");
+const externalPosts = externalPostsEntry?.data || [];
+
+// Combine internal and external posts
+const allPosts = [...posts, ...externalPosts];
+
+// Sort all posts by date
+allPosts.sort((a, b) => {
+  const dateA = "data" in a ? a.data.date : a.date;
+  const dateB = "data" in b ? b.data.date : b.date;
+  return dateB.getTime() - dateA.getTime();
+});
 ---
 
 <BaseLayout title="Alex Stephen - Writing" description="Alex Stephen - Writing">
@@ -18,5 +30,5 @@ posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
     business through the lens of data and storytelling.
   </p>
   <hr />
-  <WritingList posts={posts} />
+  <WritingList posts={allPosts} />
 </BaseLayout>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,26 +1,9 @@
 ---
-import { getCollection, getEntry } from "astro:content";
-
 import WritingList from "../components/writing/WritingList.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { getAllPosts } from "../utils/posts";
 
-const posts = await getCollection("writing", ({ data }) => {
-  return import.meta.env.PROD ? data.draft !== true : true;
-});
-
-// Get external posts
-const externalPostsEntry = await getEntry("external-posts", "external-posts");
-const externalPosts = externalPostsEntry?.data || [];
-
-// Combine internal and external posts
-const allPosts = [...posts, ...externalPosts];
-
-// Sort all posts by date
-allPosts.sort((a, b) => {
-  const dateA = "data" in a ? a.data.date : a.date;
-  const dateB = "data" in b ? b.data.date : b.date;
-  return dateB.getTime() - dateA.getTime();
-});
+const allPosts = await getAllPosts();
 ---
 
 <BaseLayout title="Alex Stephen - Writing" description="Alex Stephen - Writing">

--- a/src/pages/writing/tags/[tag].astro
+++ b/src/pages/writing/tags/[tag].astro
@@ -1,57 +1,19 @@
 ---
-import { getCollection, getEntry } from "astro:content";
-
 import WritingList from "../../../components/writing/WritingList.astro";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { getAllTags, getPostsByTag } from "../../../utils/posts";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("writing", ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true;
-  });
+  const uniqueTags = await getAllTags();
 
-  // Get external posts
-  const externalPostsEntry = await getEntry("external-posts", "external-posts");
-  const externalPosts = externalPostsEntry?.data || [];
-
-  // Collect all tags from internal posts
-  const internalTags = posts.map((post) => post.data.tags).flat();
-
-  // Collect all tags from external posts
-  const externalTags = externalPosts
-    .filter((post) => post.tags)
-    .map((post) => post.tags)
-    .flat();
-
-  const uniqueTags = [...new Set([...internalTags, ...externalTags])];
-
-  return uniqueTags.map((tag) => {
-    // Filter internal posts by tag
-    const filteredInternalPosts = posts.filter((post) =>
-      post.data.tags.includes(tag)
-    );
-
-    // Filter external posts by tag
-    const filteredExternalPosts = externalPosts.filter(
-      (post) => post.tags && post.tags.includes(tag)
-    );
-
-    // Combine and sort by date
-    const allPosts = [...filteredInternalPosts, ...filteredExternalPosts];
-    allPosts.sort((a, b) => {
-      const dateA = "data" in a ? a.data.date : a.date;
-      const dateB = "data" in b ? b.data.date : b.date;
-      return dateB.getTime() - dateA.getTime();
-    });
-
-    return {
-      params: { tag },
-      props: { posts: allPosts },
-    };
-  });
+  return uniqueTags.map((tag) => ({
+    params: { tag },
+    props: { tag },
+  }));
 }
 
 const { tag } = Astro.params;
-const { posts } = Astro.props;
+const posts = await getPostsByTag(tag);
 ---
 
 <BaseLayout

--- a/src/pages/writing/tags/[tag].astro
+++ b/src/pages/writing/tags/[tag].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 
 import WritingList from "../../../components/writing/WritingList.astro";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
@@ -9,12 +9,43 @@ export async function getStaticPaths() {
     return import.meta.env.PROD ? data.draft !== true : true;
   });
 
-  const uniqueTags = [...new Set(posts.map((post) => post.data.tags).flat())];
+  // Get external posts
+  const externalPostsEntry = await getEntry("external-posts", "external-posts");
+  const externalPosts = externalPostsEntry?.data || [];
+
+  // Collect all tags from internal posts
+  const internalTags = posts.map((post) => post.data.tags).flat();
+
+  // Collect all tags from external posts
+  const externalTags = externalPosts
+    .filter((post) => post.tags)
+    .map((post) => post.tags)
+    .flat();
+
+  const uniqueTags = [...new Set([...internalTags, ...externalTags])];
+
   return uniqueTags.map((tag) => {
-    const filteredPosts = posts.filter((post) => post.data.tags.includes(tag));
+    // Filter internal posts by tag
+    const filteredInternalPosts = posts.filter((post) =>
+      post.data.tags.includes(tag)
+    );
+
+    // Filter external posts by tag
+    const filteredExternalPosts = externalPosts.filter(
+      (post) => post.tags && post.tags.includes(tag)
+    );
+
+    // Combine and sort by date
+    const allPosts = [...filteredInternalPosts, ...filteredExternalPosts];
+    allPosts.sort((a, b) => {
+      const dateA = "data" in a ? a.data.date : a.date;
+      const dateB = "data" in b ? b.data.date : b.date;
+      return dateB.getTime() - dateA.getTime();
+    });
+
     return {
       params: { tag },
-      props: { posts: filteredPosts },
+      props: { posts: allPosts },
     };
   });
 }

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,95 @@
+import { getCollection, getEntry } from "astro:content";
+
+type InternalPost = Awaited<ReturnType<typeof getCollection<"writing">>>[0];
+type ExternalPost = {
+  title: string;
+  url: string;
+  site: string;
+  date: Date;
+  tags?: string[];
+  description?: string;
+};
+
+export type Post = InternalPost | ExternalPost;
+
+/**
+ * Fetches all posts (internal and external) and returns them sorted by date
+ */
+export async function getAllPosts(): Promise<Post[]> {
+  // Get internal posts
+  const internalPosts = await getCollection("writing", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+
+  // Get external posts
+  const externalPostsEntry = await getEntry("external-posts", "external-posts");
+  const externalPosts = externalPostsEntry?.data || [];
+
+  // Combine and sort
+  const allPosts = [...internalPosts, ...externalPosts];
+  return sortPostsByDate(allPosts);
+}
+
+/**
+ * Fetches all posts for a specific tag and returns them sorted by date
+ */
+export async function getPostsByTag(tag: string): Promise<Post[]> {
+  // Get internal posts
+  const internalPosts = await getCollection("writing", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+
+  // Get external posts
+  const externalPostsEntry = await getEntry("external-posts", "external-posts");
+  const externalPosts = externalPostsEntry?.data || [];
+
+  // Filter internal posts by tag
+  const filteredInternalPosts = internalPosts.filter((post) =>
+    post.data.tags.includes(tag)
+  );
+
+  // Filter external posts by tag
+  const filteredExternalPosts = externalPosts.filter(
+    (post) => post.tags && post.tags.includes(tag)
+  );
+
+  // Combine and sort
+  const allPosts = [...filteredInternalPosts, ...filteredExternalPosts];
+  return sortPostsByDate(allPosts);
+}
+
+/**
+ * Gets all unique tags from both internal and external posts
+ */
+export async function getAllTags(): Promise<string[]> {
+  // Get internal posts
+  const internalPosts = await getCollection("writing", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+
+  // Get external posts
+  const externalPostsEntry = await getEntry("external-posts", "external-posts");
+  const externalPosts = externalPostsEntry?.data || [];
+
+  // Collect all tags from internal posts
+  const internalTags = internalPosts.map((post) => post.data.tags).flat();
+
+  // Collect all tags from external posts
+  const externalTags = externalPosts
+    .filter((post) => post.tags)
+    .map((post) => post.tags!)
+    .flat();
+
+  return [...new Set([...internalTags, ...externalTags])];
+}
+
+/**
+ * Sorts posts by date (newest first) regardless of whether they're internal or external
+ */
+function sortPostsByDate(posts: Post[]): Post[] {
+  return posts.sort((a, b) => {
+    const dateA = "data" in a ? a.data.date : a.date;
+    const dateB = "data" in b ? b.data.date : b.date;
+    return dateB.getTime() - dateA.getTime();
+  });
+}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,16 +1,23 @@
 import { getCollection, getEntry } from "astro:content";
 
 type InternalPost = Awaited<ReturnType<typeof getCollection<"writing">>>[0];
-type ExternalPost = {
+
+export type ExternalPost = {
   title: string;
   url: string;
   site: string;
   date: Date;
   tags?: string[];
-  description?: string;
 };
 
 export type Post = InternalPost | ExternalPost;
+
+/**
+ * Type guard to check if a post is an external post
+ */
+export function isExternalPost(post: Post): post is ExternalPost {
+  return "url" in post;
+}
 
 /**
  * Fetches all posts (internal and external) and returns them sorted by date


### PR DESCRIPTION
Implemented a system to display external blog posts alongside site posts:
- Created YAML data collection for external posts (no Markdown files needed)
- Added ExternalBlogPost component with distinct styling (blue border, external link icon, site name)
- Updated WritingList to handle both internal and external posts
- Updated writing index and tag pages to merge and sort both post types
- External posts are fully taggable and appear in tag filtering

External posts appear visually distinct with:
- Left border in blue to differentiate from internal posts
- External link icon next to title
- Site name displayed prominently
- Optional description field
- Links open in new tab