### PR TITLE
Add custom social preview image

### DIFF
--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,24 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background gradient -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a8a;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#3b82f6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+
+  <!-- Main content -->
+  <text x="600" y="280" font-family="Arial, sans-serif" font-size="84" font-weight="bold" fill="white" text-anchor="middle">
+    Alex Stephen
+  </text>
+
+  <text x="600" y="350" font-family="Arial, sans-serif" font-size="36" fill="#e0e7ff" text-anchor="middle">
+    Software Engineer
+  </text>
+
+  <!-- Bottom accent line -->
+  <line x1="400" y1="450" x2="800" y2="450" stroke="#93c5fd" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -23,9 +23,8 @@ const { title, description } = Astro.props;
     openGraph={{
       basic: {
         title: title,
-        type: "A type.",
-        image:
-          "https://user-images.githubusercontent.com/5182256/131216951-8f74f425-f775-463d-a11b-0e01ad9fce8d.png",
+        type: "website",
+        image: "https://www.alexstephen.me/og-image.svg",
       },
     }}
     twitter={{
@@ -38,8 +37,7 @@ const { title, description } = Astro.props;
       meta: [
         {
           name: "twitter:image",
-          content:
-            "https://user-images.githubusercontent.com/5182256/131216951-8f74f425-f775-463d-a11b-0e01ad9fce8d.png",
+          content: "https://www.alexstephen.me/og-image.svg",
         },
         { name: "twitter:title", content: title },
         { name: "twitter:description", content: description },


### PR DESCRIPTION
Replace the default Astro SEO preview image with a custom branded image
for better social media sharing on platforms like LinkedIn and Slack.

Changes:
- Created new social preview image (og-image.svg) with site branding
- Updated Head.astro to reference the new image for both Open Graph and Twitter
- Fixed Open Graph type from "A type." to "website"